### PR TITLE
新聞のタイトルクリックで該当スレッドに遷移する機能の実装

### DIFF
--- a/api/models.ts
+++ b/api/models.ts
@@ -37,6 +37,7 @@ type RegisterPostModel = {
 };
 
 type ThreadData = {
+    threadId: string;
     title: string;
     summary: string | null;
 };

--- a/api/newspaperContent.ts
+++ b/api/newspaperContent.ts
@@ -119,8 +119,9 @@ const getThreadSummaryList = async (ctx: Context) => {
             return ctx.text("threads not found", 404);
         }
         titleAndSummaryList.push({
-            "title": thread.value.title,
-            "summary": thread.value.summary,
+            threadId: thread.value.uuid,
+            title: thread.value.title,
+            summary: thread.value.summary,
         });
     }
 

--- a/public/newspaper.css
+++ b/public/newspaper.css
@@ -88,6 +88,8 @@ body {
     padding: 5px;
     writing-mode: vertical-rl;
     font-family: "OradanoGSRR", sans-serif;
+    color: black;
+    text-decoration: none;
 }
 
 /* 記事本文 */

--- a/public/newspaper.html
+++ b/public/newspaper.html
@@ -23,23 +23,23 @@
                 </div>
                 <div class="article-container-1">
                     <div class="article-1-content article-body clickable-article"></div>
-                    <div class="article-1-title headline"></div>
+                    <a class="article-1-title headline"></a>
                 </div>
                 <div class="article-container-2">
                     <div class="article-2-content article-body clickable-article"></div>
-                    <div class="article-2-title headline"></div>
+                    <a class="article-2-title headline"></a>
                 </div>
                 <div class="article-container-3">
                     <div class="article-3-content article-body clickable-article"></div>
-                    <div class="article-3-title headline"></div>
+                    <a class="article-3-title headline"></a>
                 </div>
                 <div class="article-container-4">
                     <div class="article-4-content article-body clickable-article"></div>
-                    <div class="article-4-title headline"></div>
+                    <a class="article-4-title headline"></a>
                 </div>
                 <div class="article-container-5">
                     <div class="article-5-content article-body clickable-article"></div>
-                    <div class="article-5-title headline"></div>
+                    <a class="article-5-title headline"></a>
                 </div>
             </div>
 
@@ -59,9 +59,6 @@
         const queryString = window.location.search;
         const params = new URLSearchParams(queryString);
         const newspaperId = params.get("newspaper-id");
-
-        // const testDate = "2025年8月25日（月）";
-        let testContents = [];
 
         document.addEventListener("DOMContentLoaded", async () => {
             const modal = document.getElementById("articleModal");
@@ -84,16 +81,13 @@
                 const contentsList = responseToJson.map((contents) => ({
                     title: contents.title,
                     summary: contents.summary ?? "null",
+                    threadId: contents.threadId,
                 }));
-                // 配列の内容を順に表示
-                if (contentsList) {
-                    testContents = contentsList;
-                }
 
                 for (let i = 0; i < articleBodyList.length; i++) {
                     articleBodyList[i].textContent = "";
 
-                    const lines = testContents[i].summary.split("\n").filter((line) =>
+                    const lines = contentsList[i].summary.split("\n").filter((line) =>
                         line.trim() !== ""
                     );
 
@@ -105,16 +99,18 @@
                 }
 
                 for (let i = 0; i < articleHeadlineList.length; i++) {
-                    articleHeadlineList[i].textContent = testContents[i].title;
+                    articleHeadlineList[i].textContent = contentsList[i].title;
+                    articleHeadlineList[i].href =
+                        `/thread?newspaper-id=${newspaperId}&index=${i}&thread-id=${
+                            contentsList[i].threadId
+                        }`;
                 }
 
                 // 記事クリック時の処理
                 for (let i = 0; i < clickableArticles.length; i++) {
                     clickableArticles[i].addEventListener("click", function () {
-                        const title = testContents[i].title;
-                        const content = testContents[i].summary.split("\n").filter((
-                            line,
-                        ) => line.trim() !== "");
+                        const title = contentsList[i].title;
+                        const content = contentsList[i].summary;
 
                         modalTitle.textContent = title;
                         modalContent.textContent = content;


### PR DESCRIPTION
## 概要

<!-- このPRの目的と概要を完結に説明してください -->
- `/newspaper`で、表示されている見出しをクリックすると、その内容が生成されたスレッド内に遷移する機能を実装
- モーダル上の本文で、なぜか","が入ってしまう不具合を修正

## 関連

<!-- このPRが関連するIssueやProjectsのタスクを追記してください -->

## テスト方法

<!-- このPRに関するテストケースなどを記述してください -->
1. `/newspaper`で、新聞を開き、見出しをクリック
2. 見出しと紐づいたスレッドが開くことを確認

## レビュアーチェックリスト

- [ ] 見出し・本文と同じ内容のスレッドに遷移した
