### PR TITLE
newspaperのurlを修正

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -62,8 +62,7 @@
                 const li = document.createElement("li");
                 li.className = "newspaper";
                 const a = document.createElement("a");
-                a.href =
-                    `http://localhost:8000/newspaper?newspaper-id=${newspaper.uuid}`;
+                a.href = `/newspaper?newspaper-id=${newspaper.uuid}`;
 
                 a.textContent = newspaper.createdAt;
                 li.appendChild(a);


### PR DESCRIPTION
## 概要

<!-- このPRの目的と概要を完結に説明してください -->
- `/newspaper`へのアクセスが`http://localhost:8000`で指定されていたので、相対パスに修正

## 関連

<!-- このPRが関連するIssueやProjectsのタスクを追記してください -->

## テスト方法

<!-- このPRに関するテストケースなどを記述してください -->

## レビュアーチェックリスト

- [ ] [デプロイ環境](https://akaishitaku-2025-summer-66--hotfix-fix-newspaper-url.deno.dev)で`/newspaper`にアクセスできた