### PR TITLE
✨ スレッドがcloseされたときに投稿できないことがわかるようにした

### DIFF
--- a/public/style-thread.css
+++ b/public/style-thread.css
@@ -136,6 +136,13 @@ button:focus {
     outline-offset: -4px;
 }
 
+button:disabled{
+    background-color: #e0e0e0;
+    border: 2px outset #e0e0e0;
+    color: #a0a0a0;
+    cursor: not-allowed;
+}
+
 /* PC表示時のスタイル調整 */
 @media (min-width: 501px) {
     body {

--- a/public/thread.js
+++ b/public/thread.js
@@ -19,6 +19,7 @@ const closeThread = () => {
     userNameInput.disabled = true;
     postContentInput.disabled = true;
     submitBtn.disabled = true;
+    postContentInput.placeholder = "このスレッドはCloseされています。";
     const closeDiv = document.createElement("div");
     closeDiv.textContent = "(Close済み)";
     titleElement.appendChild(closeDiv);


### PR DESCRIPTION
## 概要

スレッドがcloseされたときにボタンを押せないようにした
投稿入力フォームに「このスレッドはcloseされています。」と表示した

## 関連

<!-- このPRが関連するIssueやProjectsのタスクを追記してください -->

## テスト方法

1. close済のスレッドを開く
2. ページ下方を確認

## レビュアーチェックリスト

- [ ] 関連にIssueもしくはタスクのリンクがあること
